### PR TITLE
fix cwltool --validate, remove description

### DIFF
--- a/fastqc.cwl
+++ b/fastqc.cwl
@@ -28,9 +28,8 @@ requirements:
 hints:
   - class: ResourceRequirement
     coresMin: 1
-    ramMin: 4092
+    ramMin: 4092 #the process requires at least 4G of RAM
     outdirMin: 512000
-    description: "the process requires at least 4G of RAM"
 
 inputs:
   fastq_files:


### PR DESCRIPTION
Before
```sh
$ cwltool --validate fastqc.cwl
INFO Resolved 'fastqc.cwl' to 'file:///work/me/fastqc/fastqc.cwl'
ERROR Tool definition failed validation:
fastqc.cwl:29:3: invalid field `description`, expected one of: 'class', 'coresMin', 'coresMax',
                 'ramMin', 'ramMax', 'tmpdirMin', 'tmpdirMax', 'outdirMin', 'outdirMax'
```

After
```sh
$ cwltool --validate fastqc.cwl
INFO Resolved 'fastqc.cwl' to 'file:///work/me/fastqc/fastqc.cwl'
fastqc.cwl is valid CWL.
```

cwltool

```sh
$ cwltool --version
venv/bin/cwltool 2.0.20200312183052
```

